### PR TITLE
Restrict find-my-timeline service to localhost

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   find-my-timeline:
     build: .
     ports:
-      - "5000:5000"
+      - "127.0.0.1:5000:5000"
     volumes:
       - ./data:/app/data
       - ./session:/root/.find-my-timeline


### PR DESCRIPTION
By default Docker binds to `0.0.0.0` and modifies ufw rules to bypass them. This is a big security risk as it exposes the server to the internet without the user’s knowledge.